### PR TITLE
Fix performance bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RootSolvers"
 uuid = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/RootSolvers.jl
+++ b/src/RootSolvers.jl
@@ -208,7 +208,7 @@ Evaluates solution tolerance, based on ``|x2-x1|``
             method::RootSolvingMethod{FT},
             soltype::SolutionType,
             tol::Union{Nothing, AbstractTolerance} = nothing,
-            maxiters::Union{Nothing, Int} = 10_000,
+            maxiters::Int = 10_000,
             )
 
 Finds the nearest root of `f`. Returns a the value of the root `x` such
@@ -234,7 +234,7 @@ function find_zero(
     method::RootSolvingMethod{FT},
     soltype::SolutionType,
     tol::Union{Nothing, AbstractTolerance} = nothing,
-    maxiters::Union{Nothing, Int} = 10_000,
+    maxiters::Int = 10_000,
 ) where {FT <: FTypes, F <: Function}
     if tol === nothing
         tol = SolutionTolerance{eltype(FT)}(1e-3)
@@ -249,7 +249,7 @@ function Broadcast.broadcasted(
     method::RootSolvingMethod{FT},
     soltype::SolutionType,
     tol::Union{Nothing, AbstractTolerance} = nothing,
-    maxiters::Union{Nothing, Int} = 10_000,
+    maxiters::Int = 10_000,
 ) where {FT <: FTypes, F}
     if tol === nothing
         tol = SolutionTolerance{eltype(FT)}(1e-3)
@@ -453,7 +453,7 @@ function find_zero(
     soltype::SolutionType,
     tol::AbstractTolerance{FT},
     maxiters::Int,
-) where {F <: Function, F′ <: Function, FT, IT <: Int}
+) where {F <: Function, F′ <: Function, FT}
     x_history = init_history(soltype, FT)
     y_history = init_history(soltype, FT)
     if soltype isa VerboseSolution


### PR DESCRIPTION
This PR fixes a performance bug related to an unused type parameter, `, IT <: Int` for the NewtonMethod solver.
On master, Thermodynamics shows `176 bytes` allocated for the `PhaseEquil_ρeq` constructor
On this branch, Thermodynamics shows no allocations for the `PhaseEquil_ρeq` constructor

This PR also changes `maxiters::Union{Nothing, Int}` to `maxiters::Int` since it can't actually work with nothing passed.