### PR TITLE
Widen input types to Real

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RootSolvers"
 uuid = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/RootSolvers.jl
+++ b/src/RootSolvers.jl
@@ -31,7 +31,7 @@ export AbstractTolerance, ResidualTolerance, SolutionTolerance
 import ForwardDiff
 
 # Input types
-const FTypes = Union{AbstractFloat, AbstractArray}
+const FTypes = Union{Real, AbstractArray}
 
 abstract type RootSolvingMethod{FT <: FTypes} end
 Base.broadcastable(method::RootSolvingMethod) = Ref(method)
@@ -96,7 +96,7 @@ Used to return a [`VerboseSolutionResults`](@ref)
 """
 struct VerboseSolution <: SolutionType end
 
-abstract type AbstractSolutionResults{AbstractFloat} end
+abstract type AbstractSolutionResults{Real} end
 
 """
     VerboseSolutionResults{FT} <: AbstractSolutionResults{FT}
@@ -143,24 +143,24 @@ end
 SolutionResults(soltype::CompactSolution, root, converged, args...) =
     CompactSolutionResults(root, converged)
 
-init_history(::VerboseSolution, x::FT) where {FT <: AbstractFloat} = FT[x]
+init_history(::VerboseSolution, x::FT) where {FT <: Real} = FT[x]
 init_history(::CompactSolution, x) = nothing
-init_history(::VerboseSolution, ::Type{FT}) where {FT <: AbstractFloat} = FT[]
-init_history(::CompactSolution, ::Type{FT}) where {FT <: AbstractFloat} =
+init_history(::VerboseSolution, ::Type{FT}) where {FT <: Real} = FT[]
+init_history(::CompactSolution, ::Type{FT}) where {FT <: Real} =
     nothing
 
 function push_history!(
     history::Vector{FT},
     x::FT,
     ::VerboseSolution,
-) where {FT <: AbstractFloat}
+) where {FT <: Real}
     push!(history, x)
 end
 function push_history!(
     history::Nothing,
     x::FT,
     ::CompactSolution,
-) where {FT <: AbstractFloat}
+) where {FT <: Real}
     nothing
 end
 


### PR DESCRIPTION
This PR widens the input types to Real, so that we can ForwardDiff through RootSolvers.jl.