### PR TITLE
Update julia and cuda versions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 env:
-  JULIA_VERSION: "1.8.0"
-  CUDA_VERSION: "10.2"
+  JULIA_VERSION: "1.8.3"
+  CUDA_VERSION: "11.2"
 
 steps:
   - label: "init cpu env"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ steps:
     key: "init_cpu_env"
     command:
       - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "julia --project -e 'using Pkg; Pkg.precompile(strict=true)'"
+      - "julia --project -e 'using Pkg; Pkg.precompile(;strict=true)'"
       - "julia --project -e 'using Pkg; Pkg.status()'"
     agents:
       config: cpu
@@ -20,10 +20,10 @@ steps:
   - label: "init gpu env"
     key: "init_gpu_env"
     command:
-      - "julia --project -e 'using Pkg; Pkg.instantiate(verbose=true)'"
-      - "julia --project -e 'using Pkg; Pkg.precompile(strict=true)'"
-      - "julia --project=test -e 'using Pkg; Pkg.instantiate(verbose=true)'"
-      - "julia --project=test -e 'using Pkg; Pkg.precompile(strict=true)'"
+      - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia --project -e 'using Pkg; Pkg.precompile(;strict=true)'"
+      - "julia --project=test -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia --project=test -e 'using Pkg; Pkg.precompile(;strict=true)'"
       - "julia --project=test -e 'using CUDA; CUDA.versioninfo()'"
       - "julia --project=test -e 'using CUDA; CUDA.precompile_runtime()'"
     agents:

--- a/env/GPU/Project.toml
+++ b/env/GPU/Project.toml
@@ -1,7 +1,0 @@
-[deps]
-Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-CUDAdrv = "c5f51814-7f29-56b8-a69c-e4d8f6be1fde"
-CUDAnative = "be33ccc6-a3ff-5ff2-a52e-74243cff1e17"
-CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"
-RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/env/Plots/Project.toml
+++ b/env/Plots/Project.toml
@@ -1,2 +1,0 @@
-[deps]
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/test/runtests_kernel.jl
+++ b/test/runtests_kernel.jl
@@ -72,7 +72,7 @@ end
                 )
                 wait(device, event)
 
-                @test all(d_dst .≈ prob.x̃)
+                @test all(Array(d_dst) .≈ prob.x̃)
             end
         end
     end


### PR DESCRIPTION
This PR
 - updates the julia and cuda versions in CI
 - Deletes unused environments
 - Wraps result, `d_dst`, in in `Array` (`@test all(Array(d_dst) .≈ prob.x̃)`) to avoid GPU approx bug (no time to report, but revert this to see that CPU passes and GPU fails)

Perhaps the bug is of interest to @vchuravy ?