### PR TITLE
add pretty printing to `(Compact/Verbose)SolutionResults`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,9 @@ version = "0.4.2"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 ForwardDiff = "0.10"
+Printf = "<0.0.1, 1"
 julia = "1.6"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,3 +71,5 @@ end
 end
 
 include("runtests_kernel.jl")
+
+include("test_printing.jl")

--- a/test/test_printing.jl
+++ b/test/test_printing.jl
@@ -1,0 +1,41 @@
+using Printf
+
+@testset "solution pretty printing" begin
+    @testset "CompactSolution" begin
+        sol = find_zero(x -> x^2 - 100^2,
+                       SecantMethod{Float64}(0.0, 1000.0),
+                       CompactSolution());
+        sol_str = sprint(show, sol)
+        @test startswith(sol_str, "CompactSolutionResults{Float64}")
+        @test contains(sol_str, "converged")
+        sol = find_zero(x -> x^2 - 100^2,
+                              SecantMethod{Float64}(0.0, 1e3),
+                              CompactSolution(), 
+                              RelativeSolutionTolerance(eps(10.0)), 
+                              2)
+        sol_str = sprint(show, sol)
+        @test startswith(sol_str, "CompactSolutionResults{Float64}")
+        @test contains(sol_str, "failed to converge")
+    end
+    @testset "VerboseSolution" begin
+        sol = find_zero(x -> x^2 - 100^2,
+                       SecantMethod{Float64}(0.0, 1000.0),
+                       VerboseSolution());
+        sol_str = sprint(show, sol)
+        @test startswith(sol_str, "VerboseSolutionResults{Float64}")
+        @test contains(sol_str, "converged")
+        @test contains(sol_str, "Root: $(sol.root)")
+        @test contains(sol_str, "Error: $(sol.err)")
+        @test contains(sol_str, "Iterations: $(length(sol.root_history)-1)")
+        @test contains(sol_str, "History")
+        sol = find_zero(x -> x^2 - 100^2,
+                              SecantMethod{Float64}(0.0, 1e3),
+                              VerboseSolution(), 
+                              RelativeSolutionTolerance(eps(10.0)), 
+                              2)
+        sol_str = sprint(show, sol)
+        @test startswith(sol_str, "VerboseSolutionResults{Float64}")
+        @test contains(sol_str, "failed to converge")
+
+    end
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add pretty printing to `VerboseSolutionResults` and `CompactSolutionResults`

## Content
### `VerboseSolution`
Instead of
```julia
sol = find_zero(x -> x^2 - 100^2, SecantMethod{Float64}(0.0, 1000.0), VerboseSolution())
RootSolvers.VerboseSolutionResults{Float64}(99.99999999994358, true, -1.1283191270194948e-8, 11, [0.0, 1000.0, 10.0, 19.801980198019802, 342.19269102990063, 46.343480236256255, 66.55339226067036, 115.89617612520117, 97.08591709962043, 99.78250389820813, 100.00321941765937, 99.99999649519104], [-10000.0, 990000.0, -9900.0, -9607.881580237232, 107095.83779428503, -7852.281839591726, -5570.645978597342, 3431.9236404436488, -574.3247009256283, -43.45191580407845, 0.6438938965238776, -0.0007009617802395951])
```
printing of the struct, now shows:
```julia
sol = find_zero(x -> x^2 - 100^2, SecantMethod{Float64}(0.0, 1000.0), VerboseSolution())
VerboseSolutionResults{Float64}:
├── Status: converged
├── Root: 99.99999999994358
├── Error: -1.1283191270194948e-8
├── Iterations: 11
└── History:
    ├── iter  1: x =        0, err = -1e+04
    ├── iter  2: x =     1000, err = 9.9e+05
    ├── iter  3: x =       10, err = -9900
    ├── iter  4: x =   19.802, err = -9608
    ├── iter  5: x =   342.19, err = 1.071e+05
    ├── iter  6: x =   46.343, err = -7852
    ├── iter  7: x =   66.553, err = -5571
    ├── iter  8: x =    115.9, err = 3432
    ├── iter  9: x =   97.086, err = -574.3
    ├── iter 10: x =   99.783, err = -43.45
    ├── iter 11: x =      100, err = 0.6439
    └── iter 12: x =      100, err = -0.000701
```
(the word "converged" is green. If the method did not converge, the status is "failed to converge", in red)

For instances with more than 20 iterations, printing is truncated
```julia
sol = find_zero(x -> x^2 - 100^2, SecantMethod{Float64}(0.0, 100000.0), VerboseSolution(), RelativeSolutionTolerance(1e-40), 30)
VerboseSolutionResults{Float64}:
├── Status: converged
├── Root: 100.0
├── Error: 0.0
├── Iterations: 23
└── History:
    ├── iter  1: x =        0, err = -1e+04
    ├── iter  2: x =    1e+05, err = 1e+10
    ├── iter  3: x =      0.1, err = -1e+04
    ├── iter  4: x =      0.2, err = -1e+04
    ├── iter  5: x =    33333, err = 1.111e+09
    ├── iter  6: x =      0.5, err = -10000
    ├── iter  7: x =  0.79998, err = -9999
    ├── iter  8: x =   7692.7, err = 5.917e+07
    ├── iter  9: x =   2.0997, err = -9996
    ⋮            ⋮                ⋮
    ⋮            ⋮                ⋮
    ├── iter 15: x =    36.01, err = -8703
    ├── iter 16: x =   54.413, err = -7039
    ├── iter 17: x =   132.26, err = 7493
    ├── iter 18: x =   92.122, err = -1514
    ├── iter 19: x =   98.867, err = -225.3
    ├── iter 20: x =   100.05, err = 9.347
    ├── iter 21: x =      100, err = -0.05322
    ├── iter 22: x =      100, err = -1.243e-05
    ├── iter 23: x =      100, err = 1.637e-11
    └── iter 24: x =      100, err = 0
```

### `CompactSolution`
Instead of 
```julia
sol = find_zero(x -> x^2 - 100^2, SecantMethod{Float64}(0.0, 1000.0), CompactSolution())
RootSolvers.CompactSolutionResults{Float64}(99.99999999994358, true)
```
we now have
```julia
sol = find_zero(x -> x^2 - 100^2, SecantMethod{Float64}(0.0, 1000.0), CompactSolution())
CompactSolutionResults{Float64}:
├── Status: converged
└── Root: 99.99999999994358
```

