### PR TITLE
Catch division by zero in `SecantMethod`

### DIFF
--- a/src/RootSolvers.jl
+++ b/src/RootSolvers.jl
@@ -371,6 +371,17 @@ function find_zero(
         x0, y0 = x1, y1
         push_history!(x_history, x0, soltype)
         push_history!(y_history, y0, soltype)
+        if abs(Δy) ≤ 2eps(y0)  # catch for division by zero (machine-small Δy)
+            return SolutionResults(
+                soltype,
+                x0,
+                abs(Δx) ≤ 2eps(x0), # only declare convergence if Δx is small
+                y0,
+                i,
+                x_history,
+                y_history,
+            )
+        end
         x1 -= y1 * Δx / Δy
         y1 = f(x1)
         if tol(x0, x1, y1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,6 +70,21 @@ end
     end
 end
 
+@testset "Check small Δy" begin
+    # Test PR: #56
+    ## Δy is small and we converged
+    sol = find_zero(x -> x^3, SecantMethod{Float64}(1e-8, 1e-8 + 1e-24), VerboseSolution())
+    @test sol.converged === true  # Δx is small
+    y0, y1 = sol.err_history
+    @test abs(y0 - y1) ≤ 2 * eps(Float64)  # Δy is small
+
+    ## Δy is small, but we didn't converge (e.g. found two distinct roots)
+    sol = find_zero(x -> x^2 - 1, SecantMethod{Float64}(-1, 1), VerboseSolution())
+    @test sol.converged === false  # Δx is large
+    y0, y1 = sol.err_history
+    @test abs(y0 - y1) ≤ 2 * eps(Float64)  # Δy is small
+end
+
 include("runtests_kernel.jl")
 
 include("test_printing.jl")


### PR DESCRIPTION
In some (likely rare) instances, especially working with `Float32`, it's possible to get the same value `y=f(x)` for two successive `x0, x1`. In this case, a division-by-zero would occur, resulting in garbage output despite the possibility of already having converged.

This PR catches this edge case, and returns the current state. The method will be declared converged if `abs(x1-x0)` is small, otherwise it will be declared not converged (but still return).