### PR TITLE
Update tagbot default branch

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -12,4 +12,5 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
           ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
Our "main" branch used to be called "master", and this messes up tagbot. The same issue appeared with codecov, but fixing 