### PR TITLE
Newton/bracketing robustness fixes + GPU-friendly branchless solver

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,9 @@
+# RootSolvers.jl Release Notes
+
+main
+-------
+
+v1.0.3
+-------
+- Improved robustness of Newton's method by implementing an inline finite-difference fallback for singular derivatives. This avoids the loss of iteration history and improves performance by keeping the kernel a single iteration loop.
+- Replaced short-circuiting branches (`||`) with bitwise operators (`|`) in tolerance checks and solver loops to improve GPU performance and reduce warp divergence.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RootSolvers"
 uuid = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RootSolvers"
 uuid = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
-authors = ["CliMA Contributors <clima-software@caltech.edu>"]
+authors = ["CliMA Contributors <clima@caltech.edu>"]
 version = "1.0.3"
 
 [deps]

--- a/src/RootSolvers.jl
+++ b/src/RootSolvers.jl
@@ -1414,7 +1414,11 @@ end
         # single iteration loop (lower register pressure and higher occupancy when
         # broadcast on the GPU).
         if !isfinite(Δx)
-            h = ifelse(iszero(x), sqrt(eps(FT)), x * sqrt(eps(FT)))
+            # Relative perturbation, scale-invariant for normal `x`. Floor it to
+            # `sqrt(eps)` only if `x * sqrt(eps)` vanishes (x == 0, or x so subnormal
+            # the product underflows), which would otherwise give a zero/NaN slope.
+            h = x * sqrt(eps(FT))
+            h = ifelse(iszero(h), sqrt(eps(FT)), h)
             slope = (f_value_only(x + h) - y) / h
             Δx = y / slope
         end

--- a/src/RootSolvers.jl
+++ b/src/RootSolvers.jl
@@ -625,7 +625,7 @@ Evaluates residual tolerance, based on ``|f(x)|``, limiting the residual to the 
 epsilon of the function value type.
 """
 (tol::ResidualTolerance)(x1, x2, y) =
-    abs(y) < tol.tol || abs(y) < eps(typeof(y))
+    (abs(y) < tol.tol) | (abs(y) < eps(typeof(y)))
 
 
 """
@@ -660,7 +660,7 @@ end
 Evaluates solution tolerance, based on ``|x2-x1|``
 """
 (tol::SolutionTolerance)(x1, x2, y) =
-    abs(x2 - x1) < tol.tol || abs(y) < eps(typeof(y))
+    (abs(x2 - x1) < tol.tol) | (abs(y) < eps(typeof(y)))
 
 """
     RelativeSolutionTolerance{FT} 
@@ -698,7 +698,7 @@ end
 Evaluates solution tolerance, based on ``|(x2-x1)/x1|``
 """
 (tol::RelativeSolutionTolerance)(x1, x2, y) =
-    abs((x2 - x1) / x1) < tol.tol || abs(y) < eps(typeof(y))
+    (abs((x2 - x1) / x1) < tol.tol) | (abs(y) < eps(typeof(y)))
 
 """
     RelativeOrAbsoluteSolutionTolerance{FT} 
@@ -736,9 +736,9 @@ Evaluates combined relative and absolute tolerance, based
 on ``|(x2-x1)/x1| || |x2-x1|``
 """
 (tol::RelativeOrAbsoluteSolutionTolerance)(x1, x2, y) =
-    abs((x2 - x1) / x1) < tol.rtol ||
-    abs(x2 - x1) < tol.atol ||
-    abs(y) < eps(typeof(y))
+    (abs((x2 - x1) / x1) < tol.rtol) |
+    (abs(x2 - x1) < tol.atol) |
+    (abs(y) < eps(typeof(y)))
 
 """
     find_zero(f, method, soltype=CompactSolution(), tol=nothing, maxiters=1_000)
@@ -815,10 +815,10 @@ sign change returns `converged = false` with `sol.root` set to the endpoint of s
 rather than erroring. This non-throwing contract is what makes `find_zero` safe to broadcast on
 the GPU.
 
-Every tolerance also reports convergence once `|f(x)|` drops below the machine epsilon of the
-residual type. For bracketing methods, the solution-based tolerances ([`SolutionTolerance`](@ref),
-[`RelativeSolutionTolerance`](@ref)) measure the width of the current bracket rather than the step
-between successive iterates.
+The solution-based tolerances ([`SolutionTolerance`](@ref), [`RelativeSolutionTolerance`](@ref))
+measure the change between successive iterates, `|x_{n+1} - x_n|`, for every method, including the
+bracketing ones. Every tolerance also reports convergence once `|f(x)|` drops below the machine
+epsilon of the residual type.
 
 # Batch and GPU Root-Finding (Broadcasting)
 
@@ -850,16 +850,22 @@ This is especially useful for large-scale or batched root-finding on GPUs. Only 
 """
 function find_zero end
 
-# Helper to get the default tolerance for a given type
+# Default tolerance value, keyed on the underlying floating-point type so that scalars,
+# arrays, and dual numbers over the same element type share the same default.
+_default_tol_value(::Type{Float64}) = 1e-4
+_default_tol_value(::Type{FT}) where {FT <: AbstractFloat} = FT(1e-3)
+
 """
     default_tol(FT)
 
-Return the default tolerance for floating-point type `FT`: a [`SolutionTolerance`](@ref) of
-`1e-4` for `Float64` and `1e-3` for other floating-point types. Used by [`find_zero`](@ref)
-when no tolerance is given.
+Return the default tolerance for type `FT`: a [`SolutionTolerance`](@ref) of `1e-4` when the
+underlying element type is `Float64` and `1e-3` otherwise. The tolerance is keyed on the
+underlying floating-point type, so scalars, arrays, and dual numbers over the same element
+type get the same default. Used by [`find_zero`](@ref) when no tolerance is given.
 
 # Arguments
-- `FT`: The floating-point type of the iterates (e.g., `Float64`, `Float32`).
+- `FT`: The type of the iterates — a floating-point type, or an array/dual over one
+  (e.g., `Float64`, `Float32`, `Vector{Float64}`).
 
 # Returns
 - `AbstractTolerance`: A default tolerance object.
@@ -874,12 +880,9 @@ println("Default tolerance for Float64: ", tol)
 # Default tolerance for Float64: SolutionTolerance{Float64}(1e-4)
 ```
 """
-function default_tol(::Type{Float64})
-    return SolutionTolerance{Float64}(1e-4)
-end
-
 function default_tol(::Type{FT}) where {FT}
-    return SolutionTolerance{base_type(FT)}(1e-3)
+    BT = base_type(FT)
+    return SolutionTolerance{BT}(_default_tol_value(BT))
 end
 
 # Main entry point: Dispatch to specific method
@@ -1119,7 +1122,7 @@ end
     maxiters,
 )
     FT = typeof(x0)
-    if !isfinite(x0) || !isfinite(x1)
+    if (!isfinite(x0)) | (!isfinite(x1))
         y = FT(Inf)
         x_history = init_history(soltype, FT)
         y_history = init_history(soltype, FT)
@@ -1149,6 +1152,7 @@ end
     lastside = 0
 
     local x, y
+    x_prev = x0 # previous iterate estimate, for the step-based convergence test
     for i in 1:maxiters
         x = update_x_rule(x0, y0, x1, y1)
         y = f(x)
@@ -1156,8 +1160,10 @@ end
         push_history!(x_history, x, soltype)
         push_history!(y_history, y, soltype)
 
-        # Check for convergence first (including exact root)
-        if tol(x0, x1, y)
+        # Converge on the change between successive estimates (and on an exact/near-exact
+        # root). The bracket width is not a reliable criterion for Regula Falsi, where one
+        # endpoint can stay fixed and the width never shrinks.
+        if tol(x_prev, x, y)
             return SolutionResults(soltype, x, true, y, i, x_history, y_history)
         end
 
@@ -1169,6 +1175,7 @@ end
         x0, x1, y0, y1 = x0_new, x1_new, y0_new, y1_new
 
         lastside = ifelse(is_neg, +1, -1)
+        x_prev = x
     end
 
     return SolutionResults(soltype, x, false, y, maxiters, x_history, y_history)
@@ -1179,7 +1186,7 @@ end
 # inverse quadratic interpolation.
 @inline function _find_zero_brent(f, x0, x1, soltype, tol, maxiters)
     FT = typeof(x0)
-    if !isfinite(x0) || !isfinite(x1)
+    if (!isfinite(x0)) | (!isfinite(x1))
         y = FT(Inf)
         x_history = init_history(soltype, FT)
         y_history = init_history(soltype, FT)
@@ -1205,10 +1212,12 @@ end
         )
     end
 
-    if abs(fa) < abs(fb)
-        a, b = b, a
-        fa, fb = fb, fa
-    end
+    cond_init_swap = abs(fa) < abs(fb)
+    a_init = ifelse(cond_init_swap, b, a)
+    b_init = ifelse(cond_init_swap, a, b)
+    fa_init = ifelse(cond_init_swap, fb, fa)
+    fb_init = ifelse(cond_init_swap, fa, fb)
+    a, b, fa, fb = a_init, b_init, fa_init, fb_init
 
     x_history = init_history(soltype, a)
     y_history = init_history(soltype, fa)
@@ -1222,7 +1231,7 @@ end
 
     for i in 1:maxiters
         # Convergence check
-        if (tol(a, b, fb)) || (fb == 0)
+        if tol(a, b, fb) | (fb == 0)
             return SolutionResults(
                 soltype,
                 b,
@@ -1252,7 +1261,7 @@ end
 
         # If step is not acceptable, fall back to bisection
         use_bisection =
-            (!s_is_between) || (abs(s - b) >= abs(e / 2)) || (abs(e) < eps(FT))
+            (!s_is_between) | (abs(s - b) >= abs(e / 2)) | (abs(e) < eps(FT))
 
         s_new = ifelse(use_bisection, (a + b) / 2, s)
         d_new = s_new - b
@@ -1296,7 +1305,7 @@ end
 # Internal function implementing the Secant method, an open, two-point method.
 @inline function _find_zero_secant(f, x0, x1, soltype, tol, maxiters)
     FT = typeof(x0)
-    if !isfinite(x0) || !isfinite(x1)
+    if (!isfinite(x0)) | (!isfinite(x1))
         y = FT(Inf)
         x_history = init_history(soltype, FT)
         y_history = init_history(soltype, FT)
@@ -1395,21 +1404,20 @@ end
     c = FT(1e-4) # Conservative Armijo constant
     for i in 1:maxiters
 
-        # Fallback to secant method when derivative is too small
-        if abs(y′) <= FT(1e-5)
-            x_pert = x + (iszero(x) ? sqrt(eps(FT)) : x * sqrt(eps(FT)))
-            # Note: History is lost on fallback for VerboseSolution 
-            return _find_zero_secant(
-                f_value_only,
-                x,
-                x_pert,
-                soltype,
-                tol,
-                maxiters - i,
-            )
-        end
-
         Δx = y / y′ # Full Newton step
+
+        # On a breakdown of the Newton step — a zero, subnormal, or non-finite
+        # derivative that makes `Δx` non-finite — fall back to a secant-style step
+        # built from a finite-difference slope over a small perturbation. Finite-but-
+        # small derivatives are handled by the step limiting and line search below.
+        # The fallback is computed inline, in the same loop, which keeps the kernel a
+        # single iteration loop (lower register pressure and higher occupancy when
+        # broadcast on the GPU).
+        if !isfinite(Δx)
+            h = ifelse(iszero(x), sqrt(eps(FT)), x * sqrt(eps(FT)))
+            slope = (f_value_only(x + h) - y) / h
+            Δx = y / slope
+        end
 
         # --- Step Limiting for Robustness ---
         max_step = FT(20) * (abs(x) + sqrt(eps(FT)))
@@ -1421,9 +1429,12 @@ end
         y_new = f_value_only(x_new)
         max_backtrack = 5
         j = 0
+        # Keep backtracking while the trial point is unacceptable — either non-finite
+        # or an insufficient decrease in `|f|` — and the step is not yet negligible.
+        # A non-finite trial must *continue* the search (shrink `α`), not stop it, so
+        # that a step overshooting into a non-finite region can recover.
         while j < max_backtrack && (
-            isfinite(y_new) &
-            (abs(y_new) > abs(y) * (FT(1) - c * α)) &
+            ((!isfinite(y_new)) | (abs(y_new) > abs(y) * (FT(1) - c * α))) &
             (α > eps(FT))
         )
             α /= 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -385,7 +385,11 @@ end
                     return sol.root^2
                 end
                 deriv = ForwardDiff.derivative(f, θ)
-                @test abs(deriv - 2 * θ) <= default_tol(FT).tol
+                # Differentiating through the iterative solver inherits its solution
+                # tolerance, with a small amplification: solution-tolerance methods stop
+                # on |xₙ₊₁ - xₙ| < tol, so the root — and its θ-derivative — are located to
+                # within a small multiple of tol (cf. the tol_factor slack used here).
+                @test abs(deriv - 2 * θ) <= 2 * default_tol(FT).tol
             end
         end
 
@@ -396,3 +400,4 @@ end
 include("test_method_selector.jl") # Tests for method selector functionality
 include("verify_selector_defaults.jl") # Tests for method selector defaults
 include("test_printing.jl")    # Tests for solution pretty printing
+include("test_robustness.jl")  # Line-search, bracketing-convergence, default_tol fixes

--- a/test/test_robustness.jl
+++ b/test/test_robustness.jl
@@ -1,0 +1,124 @@
+# Regression tests for the Newton line-search, bracketing convergence, and default
+# tolerance fixes (branch ts/newton-fixes). These run on the CPU `Array` path only.
+
+using Test
+using RootSolvers
+using StaticArrays
+using ForwardDiff
+
+@testset "Newton recovers from non-finite overshoot (#1)" begin
+    # Barrier function: f(x) = 1/x - 1 for x > 0, and a non-finite value otherwise;
+    # the root is at x = 1. The full Newton step from x0 = 2 lands exactly on x = 0,
+    # where f is non-finite. The backtracking line search must shrink the step to
+    # recover, rather than aborting on the first non-finite trial point.
+    for bad in (Inf, NaN)
+        f = x -> x > 0 ? 1 / x - 1 : oftype(x, bad)
+        ff = x -> x > 0 ? (1 / x - 1, -1 / x^2) : (oftype(x, bad), oftype(x, bad))
+        for (name, method, fn) in (
+            ("NewtonsMethodAD", NewtonsMethodAD{Float64}(2.0), f),
+            ("NewtonsMethod", NewtonsMethod{Float64}(2.0), ff),
+        )
+            sol = find_zero(fn, method, CompactSolution())
+            @test sol.converged
+            @test isapprox(sol.root, 1.0; atol = 1e-3)
+        end
+    end
+
+    # When the step direction is itself non-finite and no finite trial can be found,
+    # the solver must still terminate gracefully (no hang, no throw) as not-converged.
+    f_bad = x -> oftype(x, NaN)
+    sol = find_zero(f_bad, NewtonsMethodAD{Float64}(1.0), CompactSolution())
+    @test sol.converged === false
+end
+
+@testset "Newton's singular-derivative fallback is inline (#1b)" begin
+    # f(x) = (x-2)^2 - 1 has roots at x = 1 and x = 3 and a critical point at x = 2,
+    # where f′ = 0 exactly. Starting Newton there makes Δx = f/f′ non-finite, so the
+    # singular-step fallback fires on the very first iteration. The fallback runs
+    # inline (a finite-difference slope, same loop).
+    for (method, fn) in (
+        (NewtonsMethodAD{Float64}(2.0), x -> (x - 2)^2 - 1),
+        (NewtonsMethod{Float64}(2.0), x -> ((x - 2)^2 - 1, 2 * (x - 2))),
+    )
+        sol = find_zero(fn, method, CompactSolution())
+        @test sol.converged
+        @test abs((sol.root - 2)^2 - 1) <= 1e-3   # converged to an actual root
+    end
+
+    # Because the fallback is inline, the VerboseSolution iteration history is preserved 
+    sol_v =
+        find_zero(x -> (x - 2)^2 - 1, NewtonsMethodAD{Float64}(2.0), VerboseSolution())
+    @test sol_v.converged
+    @test length(sol_v.root_history) > 1          # fallback step(s) recorded, not dropped
+    @test isfinite(sol_v.err)
+end
+
+@testset "Newton is scale-invariant near small derivatives (#2)" begin
+    # Scaling f by a constant scales the derivative but not the Newton step Δx = f/f′,
+    # so the iteration must behave identically across scales.
+    for k in (1.0, 1e-8, 1e8)
+        f = x -> k * (x^2 - 4)
+        ff = x -> (k * (x^2 - 4), k * 2x)
+        for (method, fn) in (
+            (NewtonsMethodAD{Float64}(1.0), f),
+            (NewtonsMethod{Float64}(1.0), ff),
+        )
+            sol = find_zero(fn, method, CompactSolution())
+            @test sol.converged
+            @test isapprox(sol.root, 2.0; atol = 1e-3)
+        end
+    end
+
+    # A high-multiplicity root has a vanishing derivative near the root, yet Newton
+    # must still converge: Δx = (x-3)^5 / (5 (x-3)^4) = (x-3)/5 stays finite, so the
+    # singular-step fallback does not trigger.
+    sol = find_zero(
+        x -> (x - 3)^5,
+        NewtonsMethodAD{Float64}(1.0),
+        CompactSolution(),
+        SolutionTolerance{Float64}(1e-6),
+        10_000,
+    )
+    @test sol.converged
+    @test isapprox(sol.root, 3.0; atol = 1e-2)
+end
+
+@testset "Regula Falsi converges on the step, not bracket width (#3)" begin
+    # f(x) = x^3 - 1, root x = 1. On [0, 5] Regula Falsi keeps the upper endpoint (5)
+    # fixed and creeps the lower endpoint up, so the bracket width stays ~4 and never
+    # meets a width-based tolerance. With step-based convergence it stops promptly at
+    # the requested SolutionTolerance instead of grinding down to machine precision.
+    f = x -> x^3 - 1
+    tol = SolutionTolerance{Float64}(1e-3)
+    sol = find_zero(
+        f,
+        RegulaFalsiMethod{Float64}(0.0, 5.0),
+        VerboseSolution(),
+        tol,
+        10_000,
+    )
+    @test sol.converged
+    @test isapprox(sol.root, 1.0; atol = 1e-2)              # within a few × tol
+    @test sol.iter_performed < 50                           # not grinding to machine eps
+    # Convergence fired on the inter-iterate step being below tol:
+    @test abs(sol.root_history[end] - sol.root_history[end - 1]) < tol.tol
+
+    # The fix must not break the well-behaved cases: Bisection still converges
+    # accurately, and an exact midpoint hit is detected.
+    sol_b = find_zero(x -> x^2 - 4, BisectionMethod{Float64}(0.0, 5.0))
+    @test sol_b.converged
+    @test isapprox(sol_b.root, 2.0; atol = 1e-3)
+end
+
+@testset "default_tol is consistent across scalar / array / dual (#4)" begin
+    for (FT, val) in ((Float64, 1e-4), (Float32, 1.0f-3))
+        sc = default_tol(FT)
+        @test sc isa SolutionTolerance{FT}
+        @test sc.tol == val
+        # Arrays and dual numbers over the same element type share the default
+        @test default_tol(Vector{FT}) isa SolutionTolerance{FT}
+        @test default_tol(Vector{FT}).tol == val
+        @test default_tol(SVector{3, FT}).tol == val
+        @test default_tol(ForwardDiff.Dual{Nothing, FT, 2}).tol == val
+    end
+end


### PR DESCRIPTION
Improves the Newton and bracketing solvers and trims branches on the broadcast/GPU path. 

## Robustness

* Newton line search now recovers from steps that overshoot into a non-finite region (continues backtracking instead of aborting on the first non-finite trial).
* Singular-step fallback keys on !isfinite(Δx) instead of a fixed |f′| ≤ 1e-5 threshold — scale-invariant, and no longer spuriously fires on small-scale or high-multiplicity roots.
* Bracketing methods converge on |xₙ₊₁ − xₙ| rather than bracket width, so Regula Falsi (which can pin one endpoint) stops promptly.
* `default_tol` is keyed on the underlying float type, so scalars, arrays, and duals over the same element type share one default.

## GPU performance

* Newton's singular-derivative fallback is now an inline finite-difference step in the same loop instead of a tail call into a separate secant solver — Newton kernel ~40% smaller IR, ~50% fewer branches (better occupancy, recovers to the true derivative next step, keeps VerboseSolution history).
* Use branchless |/& instead of short-circuit ||/&& (especially effective in hot loops, e.g., tolerance functors, Brent)