### PR TITLE
Update cla action so gha bot can trigger

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,7 +9,7 @@ permissions:
 
 on:
   merge_group:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
     branches:
       - main


### PR DESCRIPTION
The GitHub Actions bot opens un-merge-able PRs because the CLA check does not get triggered. This is because `pull_request_target` does not trigger a workflow. Read more [here](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token#using-the-github_token-in-a-workflow)