### PR TITLE
Updates to bracketing methods: Options for explicit fixed iteration count and input of initial function eval

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,29 @@
 main
 -------
 
+v1.1.0
+-------
+
+- Added pre-evaluated endpoint support for the two-point methods: `find_zero(f, MethodType,
+  x0, x1, y0, y1, ...)` accepts the endpoint residuals `y0 = f(x0)`, `y1 = f(x1)` so
+  if they were already evaluated by the caller (e.g. while scanning for a bracket), they
+  can be reused, avoiding redundant function evaluations. Supported for `SecantMethod`,
+  `BisectionMethod`, `RegulaFalsiMethod`, and `BrentsMethod`.
+- Added `BracketedSolution`, a GPU-compatible solution type that additionally returns the
+  final two-point state `(x0, x1, y0, y1)` of the solver, enabling caller-side convergence
+  checks and post-processing.
+- Added `NoTolerance`, a convergence criterion to force the solver to run for exactly
+  `maxiters` iterations with no data-dependent early exit. This gives uniform per-point
+  work in fixed-iteration GPU workloads.
+- In the shared bracketing kernel (bisection/regula falsi), a converged solution now
+  reports the bracket state *after* incorporating the accepted iterate (relevant only for
+  `BracketedSolution`); returned roots and convergence flags are unchanged.
+- Fixed an `UndefVarError` in the bracketing methods when called with `maxiters <= 0`;
+  they now return the smaller-residual endpoint with `converged = false` (or as assessed
+  by the tolerance).
+
 v1.0.3
 -------
+
 - Improved robustness of Newton's method by implementing an inline finite-difference fallback for singular derivatives. This avoids the loss of iteration history and improves performance by keeping the kernel a single iteration loop.
 - Replaced short-circuiting branches (`||`) with bitwise operators (`|`) in tolerance checks and solver loops to improve GPU performance and reduce warp divergence.

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@ v1.1.0
   if they were already evaluated by the caller (e.g. while scanning for a bracket), they
   can be reused, avoiding redundant function evaluations. Supported for `SecantMethod`,
   `BisectionMethod`, `RegulaFalsiMethod`, and `BrentsMethod`.
-- Added `BracketedSolution`, a GPU-compatible solution type that additionally returns the
+- Added `TwoPointSolution`, a GPU-compatible solution type that additionally returns the
   final two-point state `(x0, x1, y0, y1)` of the solver, enabling caller-side convergence
   checks and post-processing.
 - Added `NoTolerance`, a convergence criterion to force the solver to run for exactly
@@ -19,10 +19,9 @@ v1.1.0
   work in fixed-iteration GPU workloads.
 - In the shared bracketing kernel (bisection/regula falsi), a converged solution now
   reports the bracket state *after* incorporating the accepted iterate (relevant only for
-  `BracketedSolution`); returned roots and convergence flags are unchanged.
-- Fixed an `UndefVarError` in the bracketing methods when called with `maxiters <= 0`;
-  they now return the smaller-residual endpoint with `converged = false` (or as assessed
-  by the tolerance).
+  `TwoPointSolution`); returned roots and convergence flags are unchanged.
+- Fixed an `UndefVarError` in the bracketing methods when called with `maxiters = 0`
+  (or negative, which shouldn't be used); they now return the smaller-residual endpoint with `converged = false` (or as assessed by the tolerance).
 
 v1.0.3
 -------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RootSolvers"
 uuid = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
 authors = ["CliMA Contributors <clima@caltech.edu>"]
-version = "1.0.3"
+version = "1.1.0"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -50,16 +50,19 @@ NewtonsMethod
 
 These types control the level of detail in the output returned by `find_zero`.
 
-| Solution Type             | Features                            | Best For                                     |
-|:--------------------------|:------------------------------------|:---------------------------------------------|
-| [`CompactSolution`](@ref) | Minimal output, GPU-friendly        | **High-performance**, GPU, memory efficiency |
-| [`VerboseSolution`](@ref) | Full diagnostics, iteration history | **Debugging**, analysis, CPU                 |
+| Solution Type               | Features                                  | Best For                                       |
+|:----------------------------|:------------------------------------------|:------------------------------------------------|
+| [`CompactSolution`](@ref)   | Minimal output, GPU-friendly              | **High-performance**, GPU, memory efficiency   |
+| [`VerboseSolution`](@ref)   | Full diagnostics, iteration history       | **Debugging**, analysis, CPU                   |
+| [`BracketedSolution`](@ref) | Final two-point state, GPU-friendly       | **Caller-side convergence policies**, two-point methods |
 
 ```@docs
 CompactSolution
 VerboseSolution
+BracketedSolution
 CompactSolutionResults
 VerboseSolutionResults
+BracketedSolutionResults
 ```
 
 ---
@@ -74,6 +77,7 @@ Tolerance types define the convergence criteria for the solver.
 | [`ResidualTolerance`](@ref)                   | `abs(f(x))`           | When you want the function value near **zero** |
 | [`RelativeSolutionTolerance`](@ref)           | `abs((x₂ - x₁)/x₁)`   | When root magnitude **varies widely**          |
 | [`RelativeOrAbsoluteSolutionTolerance`](@ref) | Relative or Absolute  | **Robust** for both small and large roots      |
+| [`NoTolerance`](@ref)                         | Never converges       | **Fixed-iteration** (GPU-uniform) workloads    |
 
 ```@docs
 AbstractTolerance
@@ -81,6 +85,7 @@ SolutionTolerance
 ResidualTolerance
 RelativeSolutionTolerance
 RelativeOrAbsoluteSolutionTolerance
+NoTolerance
 ```
 
 ---

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -54,15 +54,15 @@ These types control the level of detail in the output returned by `find_zero`.
 |:----------------------------|:------------------------------------------|:------------------------------------------------|
 | [`CompactSolution`](@ref)   | Minimal output, GPU-friendly              | **High-performance**, GPU, memory efficiency   |
 | [`VerboseSolution`](@ref)   | Full diagnostics, iteration history       | **Debugging**, analysis, CPU                   |
-| [`BracketedSolution`](@ref) | Final two-point state, GPU-friendly       | **Caller-side convergence policies**, two-point methods |
+| [`TwoPointSolution`](@ref) | Final two-point state, GPU-friendly       | **Caller-side convergence policies**, two-point methods |
 
 ```@docs
 CompactSolution
 VerboseSolution
-BracketedSolution
+TwoPointSolution
 CompactSolutionResults
 VerboseSolutionResults
-BracketedSolutionResults
+TwoPointSolutionResults
 ```
 
 ---

--- a/src/RootSolvers.jl
+++ b/src/RootSolvers.jl
@@ -69,11 +69,12 @@ export find_zero,
 
 
 
-export SolutionType, CompactSolution, VerboseSolution
+export SolutionType, CompactSolution, VerboseSolution, BracketedSolution
 export ResidualTolerance,
     SolutionTolerance,
     RelativeSolutionTolerance,
-    RelativeOrAbsoluteSolutionTolerance
+    RelativeOrAbsoluteSolutionTolerance,
+    NoTolerance
 export method_args, value_deriv, default_tol
 
 import ForwardDiff
@@ -435,8 +436,18 @@ struct VerboseSolutionResults{FT} <: AbstractSolutionResults{FT}
     "error of the root of the equation ``f(x^*) = 0`` per iteration"
     err_history::Vector{FT}
 end
-SolutionResults(soltype::VerboseSolution, args...) =
-    VerboseSolutionResults(args...)
+# Trailing arguments (the final two-point state passed by the two-point solvers for
+# `BracketedSolution`) are accepted and ignored.
+SolutionResults(
+    soltype::VerboseSolution,
+    root,
+    converged,
+    err,
+    iter,
+    root_history,
+    err_history,
+    args...,
+) = VerboseSolutionResults(root, converged, err, iter, root_history, err_history)
 
 function Base.show(io::IO, sol::VerboseSolutionResults{FT}) where {FT}
     color = sol.converged ? :green : :red
@@ -531,10 +542,126 @@ function Base.show(io::IO, sol::CompactSolutionResults{FT}) where {FT}
     end
 end
 
+"""
+    BracketedSolution <: SolutionType
+
+A memory-efficient, GPU-compatible solution type that, in addition to the root and
+convergence status, returns the final state of the two working points of a two-point
+method: the endpoints `x0`, `x1` and their residuals `y0`, `y1`.
+
+Supported by the two-point methods ([`SecantMethod`](@ref), [`BisectionMethod`](@ref),
+[`RegulaFalsiMethod`](@ref), [`BrentsMethod`](@ref)). For the bracketing methods, the final
+points bracket the root whenever a sign change was found (`y0 * y1 <= 0`); if the input
+interval contained no sign change, the returned points are the inputs themselves and
+`converged == false`. For `SecantMethod`, the points are the last two iterates (no
+bracketing guarantee).
+
+This solution type is intended for callers that implement their own convergence policy or
+post-processing on top of the solver, e.g., assessing convergence from the final bracket
+width after a fixed number of iterations (see [`NoTolerance`](@ref)), or sharpening the
+root with a final interpolation of the bracket at no extra residual evaluation.
+
+# Accessing Results
+The returned `BracketedSolutionResults` object contains the following fields:
+- `sol.root`: The found root value.
+- `sol.converged`: Boolean indicating if the method converged.
+- `sol.err`: Residual `f(root)` at the returned root.
+- `sol.x0`, `sol.x1`: Final positions of the two working points.
+- `sol.y0`, `sol.y1`: Residuals at `x0` and `x1`.
+
+# Examples
+```julia
+sol = find_zero(x -> x^2 - 4, RegulaFalsiMethod{Float64}(0.0, 3.0), BracketedSolution())
+width = abs(sol.x1 - sol.x0)  # final bracket width
+```
+"""
+struct BracketedSolution <: SolutionType end
+
+"""
+    BracketedSolutionResults{XT, YT} <: AbstractSolutionResults{XT}
+
+Results type for `BracketedSolution`: the root and convergence status plus the final
+two-point state `(x0, x1, y0, y1)` of the solver. 
+"""
+struct BracketedSolutionResults{XT, YT} <: AbstractSolutionResults{XT}
+    "solution ``x^*`` of the root of the equation ``f(x^*) = 0``"
+    root::XT
+    "indicates convergence"
+    converged::Bool
+    "residual ``f(x^*)`` at the returned root"
+    err::YT
+    "final position of the first working point"
+    x0::XT
+    "final position of the second working point"
+    x1::XT
+    "residual at `x0`"
+    y0::YT
+    "residual at `x1`"
+    y1::YT
+end
+
+function SolutionResults(
+    soltype::BracketedSolution,
+    root,
+    converged,
+    err,
+    iter,
+    root_history,
+    err_history,
+    x0,
+    x1,
+    y0,
+    y1,
+)
+    # The root can be promoted relative to the endpoints (e.g., positions promote to dual
+    # numbers through the residuals under automatic differentiation), so promote the
+    # position and residual field groups to common types.
+    px0, px1, proot = promote(x0, x1, root)
+    py0, py1, perr = promote(y0, y1, err)
+    return BracketedSolutionResults(proot, converged, perr, px0, px1, py0, py1)
+end
+
+# One-point methods do not carry a two-point state.
+SolutionResults(
+    soltype::BracketedSolution,
+    root,
+    converged,
+    err,
+    iter,
+    root_history,
+    err_history,
+) = throw(
+    ArgumentError(
+        "BracketedSolution requires a two-point method \
+         (SecantMethod, BisectionMethod, RegulaFalsiMethod, or BrentsMethod)",
+    ),
+)
+
+function Base.show(io::IO, sol::BracketedSolutionResults{XT}) where {XT}
+    color = sol.converged ? :green : :red
+    if get(io, :compact, false)
+        # compact printing within a vector or similar
+        printstyled(io, sol.root; color)
+    else
+        # standalone printing
+        status = sol.converged ? "converged" : "failed to converge"
+        println(io, "BracketedSolutionResults{$XT}:")
+        print(io, "├── Status: ")
+        printstyled(io, status; color)
+        println(io)
+        println(io, "├── Root: ", sol.root)
+        println(io, "├── Error: ", sol.err)
+        print(io, "└── Final points: x0 = ", sol.x0, ", x1 = ", sol.x1)
+        print(io, ", y0 = ", sol.y0, ", y1 = ", sol.y1)
+    end
+end
+
 init_history(::VerboseSolution, x::FT) where {FT <: Real} = FT[x]
 init_history(::CompactSolution, x) = nothing
+init_history(::BracketedSolution, x) = nothing
 init_history(::VerboseSolution, ::Type{FT}) where {FT <: Real} = FT[]
 init_history(::CompactSolution, ::Type{FT}) where {FT <: Real} = nothing
+init_history(::BracketedSolution, ::Type{FT}) where {FT <: Real} = nothing
 
 function push_history!(
     history::Vector{FT},
@@ -547,6 +674,13 @@ function push_history!(
     history::Nothing,
     x::FT,
     ::CompactSolution,
+) where {FT <: Real}
+    nothing
+end
+function push_history!(
+    history::Nothing,
+    x::FT,
+    ::BracketedSolution,
 ) where {FT <: Real}
     nothing
 end
@@ -741,6 +875,43 @@ on ``|(x2-x1)/x1| || |x2-x1|``
     (abs(y) < eps(typeof(y)))
 
 """
+    NoTolerance{FT}
+
+A criterion that forces the solver to run for exactly `maxiters` iterations, irrespective 
+of tolerance reached, and returns `converged = false`. This is intended for GPU kernels where 
+a data-dependent early exit is undesirable.
+
+Callers can pair this with [`BracketedSolution`](@ref) and assess convergence
+themselves from the returned final state (e.g., from the bracket width
+`abs(sol.x1 - sol.x0)`).
+
+The type parameter `FT` is unused and exists only to satisfy the `AbstractTolerance{FT}`
+interface; the zero-argument constructor `NoTolerance()` is the intended entry point.
+
+!!! note
+    [`BrentsMethod`](@ref) retains an internal exact-zero exit (`f(x) == 0`) independent
+    of the tolerance, so only its iteration count — not its result — can become
+    data-dependent under `NoTolerance`.
+
+# Examples
+```julia
+# Run exactly 10 regula falsi iterations, then assess convergence from the bracket
+sol = find_zero(f, RegulaFalsiMethod{Float64}(0.0, 1.0), BracketedSolution(),
+                NoTolerance(), 10)
+converged = abs(sol.x1 - sol.x0) < 1e-3
+```
+"""
+struct NoTolerance{FT} <: AbstractTolerance{FT} end
+NoTolerance() = NoTolerance{Float64}()
+
+"""
+    (tol::NoTolerance)(x1, x2, y)
+
+Always returns `false`; see [`NoTolerance`](@ref).
+"""
+(tol::NoTolerance)(x1, x2, y) = false
+
+"""
     find_zero(f, method, soltype=CompactSolution(), tol=nothing, maxiters=1_000)
 
 Find a root of the scalar function `f` using the specified numerical method.
@@ -818,7 +989,12 @@ the GPU.
 The solution-based tolerances ([`SolutionTolerance`](@ref), [`RelativeSolutionTolerance`](@ref))
 measure the change between successive iterates, `|x_{n+1} - x_n|`, for every method, including the
 bracketing ones. Every tolerance also reports convergence once `|f(x)|` drops below the machine
-epsilon of the residual type.
+epsilon of the residual type (except [`NoTolerance`](@ref), which never reports convergence and
+runs exactly `maxiters` iterations).
+
+For the two-point methods, the endpoint residuals can be passed pre-evaluated
+(`find_zero(f, MethodType, x0, x1, y0, y1, ...)`) to avoid re-evaluating `f` at endpoints the
+caller has already probed (e.g., during a bracket search).
 
 # Batch and GPU Root-Finding (Broadcasting)
 
@@ -989,7 +1165,49 @@ function find_zero(
     tol::AbstractTolerance = default_tol(FT),
     maxiters::Int = 1_000,
 ) where {F <: Function, FT <: FTypes, M <: SecantMethod}
-    return _find_zero_secant(f, x0, x1, soltype, tol, maxiters)
+    y0, y1 = _eval_endpoints(f, x0, x1)
+    return _find_zero_secant(f, x0, x1, y0, y1, soltype, tol, maxiters)
+end
+
+"""
+    find_zero(f, method_type::Type{<:RootSolvingMethod}, x0, x1, y0, y1,
+              [soltype, tol, maxiters])
+
+Find a root of `f` with a two-point method, starting from endpoints `x0`, `x1` whose
+residuals `y0 = f(x0)` and `y1 = f(x1)` have already been evaluated by the caller.
+
+This form skips the solver's own initial endpoint evaluations, so the total number of
+residual evaluations is just the number of iterations performed. It is intended for
+callers that have already probed the function while locating a bracket (e.g., scanning a
+physical parameter range for a sign change) and want to reuse those values instead of
+carrying out two redundant evaluations per solve.
+
+Supported for the two-point methods: [`SecantMethod`](@ref), [`BisectionMethod`](@ref),
+[`RegulaFalsiMethod`](@ref), and [`BrentsMethod`](@ref). The caller is responsible for
+`y0`, `y1` actually being the residuals at `x0`, `x1`; for the bracketing methods, an
+input pair without a sign change (`y0 * y1 >= 0`) returns `converged = false` with the
+smaller-residual endpoint as the root, exactly like the standard form.
+
+# Examples
+```julia
+f(x) = x^2 - 4
+x0, x1 = 0.0, 3.0
+y0, y1 = f(x0), f(x1)   # already evaluated during bracket search
+sol = find_zero(f, RegulaFalsiMethod, x0, x1, y0, y1)
+```
+"""
+function find_zero(
+    f::F,
+    ::Type{M},
+    x0::FT,
+    x1::FT,
+    y0::YT,
+    y1::YT,
+    soltype::SolutionType = CompactSolution(),
+    tol::AbstractTolerance = default_tol(FT),
+    maxiters::Int = 1_000,
+) where {F <: Function, FT <: FTypes, YT <: FTypes, M <: SecantMethod}
+    return _find_zero_secant(f, x0, x1, y0, y1, soltype, tol, maxiters)
 end
 
 @inline method_args(method::BisectionMethod) = (method.x0, method.x1)
@@ -1002,12 +1220,40 @@ function find_zero(
     tol::AbstractTolerance = default_tol(FT),
     maxiters::Int = 1_000,
 ) where {F <: Function, FT, M <: BisectionMethod}
+    y0, y1 = _eval_endpoints(f, x0, x1)
     return _find_zero_bracketed(
         f,
         _bisection_rule,
         _bisection_y_update,
         x0,
         x1,
+        y0,
+        y1,
+        soltype,
+        tol,
+        maxiters,
+    )
+end
+
+function find_zero(
+    f::F,
+    ::Type{M},
+    x0::FT,
+    x1::FT,
+    y0::YT,
+    y1::YT,
+    soltype::SolutionType = CompactSolution(),
+    tol::AbstractTolerance = default_tol(FT),
+    maxiters::Int = 1_000,
+) where {F <: Function, FT <: FTypes, YT <: FTypes, M <: BisectionMethod}
+    return _find_zero_bracketed(
+        f,
+        _bisection_rule,
+        _bisection_y_update,
+        x0,
+        x1,
+        y0,
+        y1,
         soltype,
         tol,
         maxiters,
@@ -1024,12 +1270,40 @@ function find_zero(
     tol::AbstractTolerance = default_tol(FT),
     maxiters::Int = 1_000,
 ) where {F <: Function, FT, M <: RegulaFalsiMethod}
+    y0, y1 = _eval_endpoints(f, x0, x1)
     return _find_zero_bracketed(
         f,
         _regula_falsi_rule,
         _regula_falsi_y_update,
         x0,
         x1,
+        y0,
+        y1,
+        soltype,
+        tol,
+        maxiters,
+    )
+end
+
+function find_zero(
+    f::F,
+    ::Type{M},
+    x0::FT,
+    x1::FT,
+    y0::YT,
+    y1::YT,
+    soltype::SolutionType = CompactSolution(),
+    tol::AbstractTolerance = default_tol(FT),
+    maxiters::Int = 1_000,
+) where {F <: Function, FT <: FTypes, YT <: FTypes, M <: RegulaFalsiMethod}
+    return _find_zero_bracketed(
+        f,
+        _regula_falsi_rule,
+        _regula_falsi_y_update,
+        x0,
+        x1,
+        y0,
+        y1,
         soltype,
         tol,
         maxiters,
@@ -1046,7 +1320,22 @@ function find_zero(
     tol::AbstractTolerance = default_tol(FT),
     maxiters::Int = 1_000,
 ) where {F <: Function, FT, M <: BrentsMethod}
-    return _find_zero_brent(f, x0, x1, soltype, tol, maxiters)
+    y0, y1 = _eval_endpoints(f, x0, x1)
+    return _find_zero_brent(f, x0, x1, y0, y1, soltype, tol, maxiters)
+end
+
+function find_zero(
+    f::F,
+    ::Type{M},
+    x0::FT,
+    x1::FT,
+    y0::YT,
+    y1::YT,
+    soltype::SolutionType = CompactSolution(),
+    tol::AbstractTolerance = default_tol(FT),
+    maxiters::Int = 1_000,
+) where {F <: Function, FT <: FTypes, YT <: FTypes, M <: BrentsMethod}
+    return _find_zero_brent(f, x0, x1, y0, y1, soltype, tol, maxiters)
 end
 
 @inline method_args(method::NewtonsMethodAD) = (method.x0,)
@@ -1084,6 +1373,17 @@ end
 #### Method-specific helper functions
 ####
 
+# Evaluate the residuals at both endpoints for the standard (non-pre-evaluated) entry
+# points. Non-finite endpoints are not passed to `f`; the sentinel `Inf` residuals make
+# the kernels' input guards return a failed solution instead.
+@inline function _eval_endpoints(f::F, x0, x1) where {F}
+    if (!isfinite(x0)) | (!isfinite(x1))
+        FT = typeof(x0)
+        return FT(Inf), FT(Inf)
+    end
+    return f(x0), f(x1)
+end
+
 # --- Rules for calculating the next `x` value ---
 
 # Update rule for Bisection method: `x` is the midpoint.
@@ -1109,28 +1409,32 @@ end
 )
 
 
-# Internal function implementing the core bracketing algorithm used by bisection, 
-# Regula Falsi, and other bracketing methods.
+# Internal function implementing the core bracketing algorithm used by bisection,
+# Regula Falsi, and other bracketing methods. The endpoint residuals `y0`, `y1` are
+# supplied by the caller (either pre-evaluated by the user or computed by the standard
+# `find_zero` entry points via `_eval_endpoints`).
 @inline function _find_zero_bracketed(
     f,
     update_x_rule,
     update_y_rule,
     x0,
     x1,
+    y0,
+    y1,
     soltype,
     tol,
     maxiters,
 )
     FT = typeof(x0)
-    if (!isfinite(x0)) | (!isfinite(x1))
+    if (!isfinite(x0)) | (!isfinite(x1)) | (!isfinite(y0)) | (!isfinite(y1))
         y = FT(Inf)
         x_history = init_history(soltype, FT)
         y_history = init_history(soltype, FT)
-        return SolutionResults(soltype, x0, false, y, 0, x_history, y_history)
+        return SolutionResults(
+            soltype, x0, false, y, 0, x_history, y_history, x0, x1, y0, y1,
+        )
     end
 
-    y0 = f(x0)
-    y1 = f(x1)
     if y0 * y1 >= 0
         # Return failed solution instead of error for GPU compatibility.
         # Pick the endpoint with the smaller residual as the best guess.
@@ -1144,6 +1448,10 @@ end
             0,
             x_history,
             y_history,
+            x0,
+            x1,
+            y0,
+            y1,
         )
     end
 
@@ -1151,7 +1459,10 @@ end
     y_history = init_history(soltype, y0)
     lastside = 0
 
-    local x, y
+    # Best point so far: the smaller-residual endpoint. This is also the (well-defined)
+    # returned root when `maxiters <= 0`.
+    x = ifelse(abs(y0) < abs(y1), x0, x1)
+    y = ifelse(abs(y0) < abs(y1), y0, y1)
     x_prev = x0 # previous iterate estimate, for the step-based convergence test
     for i in 1:maxiters
         x = update_x_rule(x0, y0, x1, y1)
@@ -1160,14 +1471,9 @@ end
         push_history!(x_history, x, soltype)
         push_history!(y_history, y, soltype)
 
-        # Converge on the change between successive estimates (and on an exact/near-exact
-        # root). The bracket width is not a reliable criterion for Regula Falsi, where one
-        # endpoint can stay fixed and the width never shrinks.
-        if tol(x_prev, x, y)
-            return SolutionResults(soltype, x, true, y, i, x_history, y_history)
-        end
-
-        # Update x and y values using the provided policy rules
+        # Update x and y values using the provided policy rules. The bracket is updated
+        # before the convergence check so that a converged solution reports the tightest
+        # enclosing interval (relevant for `BracketedSolution` consumers).
         is_neg = y * y0 < 0
         x0_new = ifelse(is_neg, x0, x)
         x1_new = ifelse(is_neg, x, x1)
@@ -1175,26 +1481,42 @@ end
         x0, x1, y0, y1 = x0_new, x1_new, y0_new, y1_new
 
         lastside = ifelse(is_neg, +1, -1)
+
+        # Converge on the change between successive estimates (and on an exact/near-exact
+        # root). The bracket width is not a reliable criterion for Regula Falsi, where one
+        # endpoint can stay fixed and the width never shrinks.
+        if tol(x_prev, x, y)
+            return SolutionResults(
+                soltype, x, true, y, i, x_history, y_history, x0, x1, y0, y1,
+            )
+        end
+
         x_prev = x
     end
 
-    return SolutionResults(soltype, x, false, y, maxiters, x_history, y_history)
+    return SolutionResults(
+        soltype, x, false, y, maxiters, x_history, y_history, x0, x1, y0, y1,
+    )
 end
 
 
-# Internal function implementing Brent's method, which combines bisection, secant, and 
-# inverse quadratic interpolation.
-@inline function _find_zero_brent(f, x0, x1, soltype, tol, maxiters)
+# Internal function implementing Brent's method, which combines bisection, secant, and
+# inverse quadratic interpolation. The endpoint residuals are supplied by the caller
+# (either pre-evaluated by the user or computed by the standard `find_zero` entry points
+# via `_eval_endpoints`).
+@inline function _find_zero_brent(f, x0, x1, fa0, fb0, soltype, tol, maxiters)
     FT = typeof(x0)
-    if (!isfinite(x0)) | (!isfinite(x1))
+    if (!isfinite(x0)) | (!isfinite(x1)) | (!isfinite(fa0)) | (!isfinite(fb0))
         y = FT(Inf)
         x_history = init_history(soltype, FT)
         y_history = init_history(soltype, FT)
-        return SolutionResults(soltype, x0, false, y, 0, x_history, y_history)
+        return SolutionResults(
+            soltype, x0, false, y, 0, x_history, y_history, x0, x1, fa0, fb0,
+        )
     end
 
     a, b = x0, x1
-    fa, fb = f(a), f(b)
+    fa, fb = fa0, fb0
 
     if fa * fb >= 0
         # Return failed solution instead of error for GPU compatibility.
@@ -1209,6 +1531,10 @@ end
             0,
             x_history,
             y_history,
+            a,
+            b,
+            fa,
+            fb,
         )
     end
 
@@ -1240,6 +1566,10 @@ end
                 i,
                 x_history,
                 y_history,
+                a,
+                b,
+                fa,
+                fb,
             )
         end
 
@@ -1299,21 +1629,26 @@ end
         maxiters,
         x_history,
         y_history,
+        a,
+        b,
+        fa,
+        fb,
     )
 end
 
-# Internal function implementing the Secant method, an open, two-point method.
-@inline function _find_zero_secant(f, x0, x1, soltype, tol, maxiters)
+# Internal function implementing the Secant method, an open, two-point method. The
+# endpoint residuals `y0`, `y1` are supplied by the caller (either pre-evaluated by the
+# user or computed by the standard `find_zero` entry points via `_eval_endpoints`).
+@inline function _find_zero_secant(f, x0, x1, y0, y1, soltype, tol, maxiters)
     FT = typeof(x0)
-    if (!isfinite(x0)) | (!isfinite(x1))
+    if (!isfinite(x0)) | (!isfinite(x1)) | (!isfinite(y0)) | (!isfinite(y1))
         y = FT(Inf)
         x_history = init_history(soltype, FT)
         y_history = init_history(soltype, FT)
-        return SolutionResults(soltype, x0, false, y, 0, x_history, y_history)
+        return SolutionResults(
+            soltype, x0, false, y, 0, x_history, y_history, x0, x1, y0, y1,
+        )
     end
-
-    y0 = f(x0)
-    y1 = f(x1)
 
     x_history = init_history(soltype, x0)
     y_history = init_history(soltype, y0)
@@ -1334,6 +1669,10 @@ end
                 i,
                 x_history,
                 y_history,
+                x0,
+                x1,
+                y0,
+                y1,
             )
         end
 
@@ -1358,6 +1697,10 @@ end
                 i,
                 x_history,
                 y_history,
+                x0,
+                x1,
+                y0,
+                y1,
             )
         end
     end
@@ -1370,6 +1713,10 @@ end
         maxiters,
         x_history,
         y_history,
+        x0,
+        x1,
+        y0,
+        y1,
     )
 end
 

--- a/src/RootSolvers.jl
+++ b/src/RootSolvers.jl
@@ -1473,7 +1473,7 @@ end
 
         # Update x and y values using the provided policy rules. The bracket is updated
         # before the convergence check so that a converged solution reports the tightest
-        # enclosing interval (relevant for `BracketedSolution` consumers).
+        # enclosing interval (relevant for `BracketedSolution` users).
         is_neg = y * y0 < 0
         x0_new = ifelse(is_neg, x0, x)
         x1_new = ifelse(is_neg, x, x1)

--- a/src/RootSolvers.jl
+++ b/src/RootSolvers.jl
@@ -69,7 +69,7 @@ export find_zero,
 
 
 
-export SolutionType, CompactSolution, VerboseSolution, BracketedSolution
+export SolutionType, CompactSolution, VerboseSolution, TwoPointSolution
 export ResidualTolerance,
     SolutionTolerance,
     RelativeSolutionTolerance,
@@ -437,7 +437,7 @@ struct VerboseSolutionResults{FT} <: AbstractSolutionResults{FT}
     err_history::Vector{FT}
 end
 # Trailing arguments (the final two-point state passed by the two-point solvers for
-# `BracketedSolution`) are accepted and ignored.
+# `TwoPointSolution`) are accepted and ignored.
 SolutionResults(
     soltype::VerboseSolution,
     root,
@@ -543,7 +543,7 @@ function Base.show(io::IO, sol::CompactSolutionResults{FT}) where {FT}
 end
 
 """
-    BracketedSolution <: SolutionType
+    TwoPointSolution <: SolutionType
 
 A memory-efficient, GPU-compatible solution type that, in addition to the root and
 convergence status, returns the final state of the two working points of a two-point
@@ -562,28 +562,35 @@ width after a fixed number of iterations (see [`NoTolerance`](@ref)), or sharpen
 root with a final interpolation of the bracket at no extra residual evaluation.
 
 # Accessing Results
-The returned `BracketedSolutionResults` object contains the following fields:
+The returned `TwoPointSolutionResults` object contains the following fields:
 - `sol.root`: The found root value.
 - `sol.converged`: Boolean indicating if the method converged.
 - `sol.err`: Residual `f(root)` at the returned root.
 - `sol.x0`, `sol.x1`: Final positions of the two working points.
 - `sol.y0`, `sol.y1`: Residuals at `x0` and `x1`.
 
+!!! note
+    `y0`, `y1` are the solver's working residuals. For [`RegulaFalsiMethod`](@ref), the
+    Illinois stagnation fix may have halved a retained endpoint's residual, so they can
+    differ from `f(x0)`, `f(x1)` by a power of 2 (sign preserved). These are the values
+    the method itself would use in its next interpolation step; re-evaluate `f` if exact
+    residuals are required.
+
 # Examples
 ```julia
-sol = find_zero(x -> x^2 - 4, RegulaFalsiMethod{Float64}(0.0, 3.0), BracketedSolution())
+sol = find_zero(x -> x^2 - 4, RegulaFalsiMethod{Float64}(0.0, 3.0), TwoPointSolution())
 width = abs(sol.x1 - sol.x0)  # final bracket width
 ```
 """
-struct BracketedSolution <: SolutionType end
+struct TwoPointSolution <: SolutionType end
 
 """
-    BracketedSolutionResults{XT, YT} <: AbstractSolutionResults{XT}
+    TwoPointSolutionResults{XT, YT} <: AbstractSolutionResults{XT}
 
-Results type for `BracketedSolution`: the root and convergence status plus the final
+Results type for `TwoPointSolution`: the root and convergence status plus the final
 two-point state `(x0, x1, y0, y1)` of the solver. 
 """
-struct BracketedSolutionResults{XT, YT} <: AbstractSolutionResults{XT}
+struct TwoPointSolutionResults{XT, YT} <: AbstractSolutionResults{XT}
     "solution ``x^*`` of the root of the equation ``f(x^*) = 0``"
     root::XT
     "indicates convergence"
@@ -601,7 +608,7 @@ struct BracketedSolutionResults{XT, YT} <: AbstractSolutionResults{XT}
 end
 
 function SolutionResults(
-    soltype::BracketedSolution,
+    soltype::TwoPointSolution,
     root,
     converged,
     err,
@@ -618,12 +625,12 @@ function SolutionResults(
     # position and residual field groups to common types.
     px0, px1, proot = promote(x0, x1, root)
     py0, py1, perr = promote(y0, y1, err)
-    return BracketedSolutionResults(proot, converged, perr, px0, px1, py0, py1)
+    return TwoPointSolutionResults(proot, converged, perr, px0, px1, py0, py1)
 end
 
 # One-point methods do not carry a two-point state.
 SolutionResults(
-    soltype::BracketedSolution,
+    soltype::TwoPointSolution,
     root,
     converged,
     err,
@@ -632,12 +639,12 @@ SolutionResults(
     err_history,
 ) = throw(
     ArgumentError(
-        "BracketedSolution requires a two-point method \
+        "TwoPointSolution requires a two-point method \
          (SecantMethod, BisectionMethod, RegulaFalsiMethod, or BrentsMethod)",
     ),
 )
 
-function Base.show(io::IO, sol::BracketedSolutionResults{XT}) where {XT}
+function Base.show(io::IO, sol::TwoPointSolutionResults{XT}) where {XT}
     color = sol.converged ? :green : :red
     if get(io, :compact, false)
         # compact printing within a vector or similar
@@ -645,7 +652,7 @@ function Base.show(io::IO, sol::BracketedSolutionResults{XT}) where {XT}
     else
         # standalone printing
         status = sol.converged ? "converged" : "failed to converge"
-        println(io, "BracketedSolutionResults{$XT}:")
+        println(io, "TwoPointSolutionResults{$XT}:")
         print(io, "├── Status: ")
         printstyled(io, status; color)
         println(io)
@@ -658,10 +665,10 @@ end
 
 init_history(::VerboseSolution, x::FT) where {FT <: Real} = FT[x]
 init_history(::CompactSolution, x) = nothing
-init_history(::BracketedSolution, x) = nothing
+init_history(::TwoPointSolution, x) = nothing
 init_history(::VerboseSolution, ::Type{FT}) where {FT <: Real} = FT[]
 init_history(::CompactSolution, ::Type{FT}) where {FT <: Real} = nothing
-init_history(::BracketedSolution, ::Type{FT}) where {FT <: Real} = nothing
+init_history(::TwoPointSolution, ::Type{FT}) where {FT <: Real} = nothing
 
 function push_history!(
     history::Vector{FT},
@@ -680,7 +687,7 @@ end
 function push_history!(
     history::Nothing,
     x::FT,
-    ::BracketedSolution,
+    ::TwoPointSolution,
 ) where {FT <: Real}
     nothing
 end
@@ -881,9 +888,12 @@ A criterion that forces the solver to run for exactly `maxiters` iterations, irr
 of tolerance reached, and returns `converged = false`. This is intended for GPU kernels where 
 a data-dependent early exit is undesirable.
 
-Callers can pair this with [`BracketedSolution`](@ref) and assess convergence
-themselves from the returned final state (e.g., from the bracket width
-`abs(sol.x1 - sol.x0)`).
+Callers assess convergence themselves from the returned state. On the GPU, pair it with
+[`TwoPointSolution`](@ref) (`isbits`, non-allocating) and check the bracket width
+`abs(sol.x1 - sol.x0)`, or with [`CompactSolution`](@ref) and re-evaluate `f(sol.root)`.
+On the CPU, [`VerboseSolution`](@ref) gives the richest picture — the final residual
+`sol.err` and the full `sol.root_history`/`sol.err_history` — but allocates, so it is
+CPU-only.
 
 The type parameter `FT` is unused and exists only to satisfy the `AbstractTolerance{FT}`
 interface; the zero-argument constructor `NoTolerance()` is the intended entry point.
@@ -895,8 +905,12 @@ interface; the zero-argument constructor `NoTolerance()` is the intended entry p
 
 # Examples
 ```julia
-# Run exactly 10 regula falsi iterations, then assess convergence from the bracket
-sol = find_zero(f, RegulaFalsiMethod{Float64}(0.0, 1.0), BracketedSolution(),
+# Fixed-cost GPU-style solve: endpoint residuals already known from a bracket
+# search, exactly 10 regula falsi iterations (10 residual evaluations, no
+# data-dependent exit), convergence assessed by the caller from the bracket width
+x0, x1 = 0.0, 1.0
+y0, y1 = f(x0), f(x1)   # evaluated while locating the bracket
+sol = find_zero(f, RegulaFalsiMethod, x0, x1, y0, y1, TwoPointSolution(),
                 NoTolerance(), 10)
 converged = abs(sol.x1 - sol.x0) < 1e-3
 ```
@@ -933,11 +947,14 @@ supports various root-finding algorithms, tolerance criteria, and solution forma
 - `soltype::`[`SolutionType`](@ref): Format of the returned solution (default: [`CompactSolution`](@ref)):
     - [`CompactSolution`](@ref): Returns only root and convergence status (GPU-compatible)
     - [`VerboseSolution`](@ref): Returns detailed diagnostics and iteration history (CPU-only)
+    - [`TwoPointSolution`](@ref): Additionally returns the final two-point state
+      `(x0, x1, y0, y1)` (two-point methods only; GPU-compatible)
 - `tol::Union{Nothing, AbstractTolerance}`: Convergence criterion. If `nothing` (default), uses [`SolutionTolerance`](@ref)`(1e-4)` for `Float64` or `1e-3` otherwise. Available tolerance types:
     - [`ResidualTolerance`](@ref): Based on `|f(x)|`
     - [`SolutionTolerance`](@ref): Based on `|x_{n+1} - x_n|`
     - [`RelativeSolutionTolerance`](@ref): Based on `|(x_{n+1} - x_n)/x_n|`
     - [`RelativeOrAbsoluteSolutionTolerance`](@ref): Combined relative and absolute tolerance
+    - [`NoTolerance`](@ref): Never converges; runs exactly `maxiters` iterations (fixed-iteration GPU workloads)
 - `maxiters::Int`: Maximum number of iterations allowed (default: 1,000)
 
 # Returns
@@ -945,6 +962,8 @@ supports various root-finding algorithms, tolerance criteria, and solution forma
   The exact type depends on the `soltype` parameter:
   - `CompactSolutionResults`: Contains `root` and `converged` fields
   - `VerboseSolutionResults`: Additionally contains `err`, `iter_performed`, and iteration history
+  - `TwoPointSolutionResults`: Contains `root`, `converged`, `err`, and the final
+    two-point state `x0`, `x1`, `y0`, `y1` (two-point methods only; see [`TwoPointSolution`](@ref))
 
 # Examples
 
@@ -1009,7 +1028,9 @@ x0 = CUDA.fill(1.0, 1000)  # 1000 initial guesses on the GPU
 sol = find_zero.(x -> x.^2 .- 2, SecantMethod, x0, x0 .+ 1, CompactSolution())
 ```
 
-This is especially useful for large-scale or batched root-finding on GPUs. Only [`CompactSolution`](@ref) is GPU-compatible.
+This is especially useful for large-scale or batched root-finding on GPUs. Only
+[`CompactSolution`](@ref) and [`TwoPointSolution`](@ref) are GPU-compatible
+([`VerboseSolution`](@ref) stores iteration history and is CPU-only).
 
 # Method Selection Guide
 - **BisectionMethod**: Simple general-purpose bracketing method, slow but guaranteed convergence
@@ -1021,8 +1042,8 @@ This is especially useful for large-scale or batched root-finding on GPUs. Only 
 
 # See Also
 - [`BisectionMethod`](@ref), [`SecantMethod`](@ref), [`RegulaFalsiMethod`](@ref), [`BrentsMethod`](@ref), [`NewtonsMethodAD`](@ref), [`NewtonsMethod`](@ref)
-- [`CompactSolution`](@ref), [`VerboseSolution`](@ref)
-- [`ResidualTolerance`](@ref), [`SolutionTolerance`](@ref)
+- [`CompactSolution`](@ref), [`VerboseSolution`](@ref), [`TwoPointSolution`](@ref)
+- [`ResidualTolerance`](@ref), [`SolutionTolerance`](@ref), [`NoTolerance`](@ref)
 """
 function find_zero end
 
@@ -1138,6 +1159,8 @@ The required `args...` depend on the specific `method_type` chosen:
   The exact type depends on the `soltype` parameter:
   - `CompactSolutionResults`: Contains `root` and `converged` fields
   - `VerboseSolutionResults`: Additionally contains `err`, `iter_performed`, and iteration history
+  - `TwoPointSolutionResults`: Contains `root`, `converged`, `err`, and the final
+    two-point state `x0`, `x1`, `y0`, `y1` (two-point methods only; see [`TwoPointSolution`](@ref))
 
 # Examples
 
@@ -1369,6 +1392,40 @@ function find_zero(
     return _find_zero_newton(f, x -> f(x)[1], x0, soltype, tol, maxiters)
 end
 
+# Fail fast for the one-point methods paired with `TwoPointSolution`: a one-point method
+# has no two-point state to report. These guards throw at dispatch, before any iteration,
+# rather than letting the solve run and hit the same error at result construction (the
+# `SolutionResults(::TwoPointSolution, ...)` backstop). One guard per one-point method,
+# each mirroring the `M` constraint of the method it shadows and narrowing only the
+# `soltype` argument (`TwoPointSolution` < `SolutionType`); a single `Union{...}` guard
+# would be more specific on `soltype` but less specific on `M`, and hence ambiguous.
+@inline _no_two_point_state() = throw(
+    ArgumentError(
+        "TwoPointSolution requires a two-point method \
+         (SecantMethod, BisectionMethod, RegulaFalsiMethod, or BrentsMethod)",
+    ),
+)
+function find_zero(
+    f::F,
+    ::Type{M},
+    x0::FT,
+    soltype::TwoPointSolution,
+    tol::AbstractTolerance = default_tol(FT),
+    maxiters::Int = 1_000,
+) where {F <: Function, FT, M <: NewtonsMethodAD}
+    _no_two_point_state()
+end
+function find_zero(
+    f::F,
+    ::Type{M},
+    x0::FT,
+    soltype::TwoPointSolution,
+    tol::AbstractTolerance = default_tol(FT),
+    maxiters::Int = 1_000,
+) where {F <: Function, FT, M <: NewtonsMethod}
+    _no_two_point_state()
+end
+
 ####
 #### Method-specific helper functions
 ####
@@ -1473,7 +1530,7 @@ end
 
         # Update x and y values using the provided policy rules. The bracket is updated
         # before the convergence check so that a converged solution reports the tightest
-        # enclosing interval (relevant for `BracketedSolution` users).
+        # enclosing interval (relevant for `TwoPointSolution` users).
         is_neg = y * y0 < 0
         x0_new = ifelse(is_neg, x0, x)
         x1_new = ifelse(is_neg, x, x1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -401,3 +401,4 @@ include("test_method_selector.jl") # Tests for method selector functionality
 include("verify_selector_defaults.jl") # Tests for method selector defaults
 include("test_printing.jl")    # Tests for solution pretty printing
 include("test_robustness.jl")  # Line-search, bracketing-convergence, default_tol fixes
+include("test_fval_inputs.jl") # Pre-evaluated endpoints, BracketedSolution, NoTolerance

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -401,4 +401,4 @@ include("test_method_selector.jl") # Tests for method selector functionality
 include("verify_selector_defaults.jl") # Tests for method selector defaults
 include("test_printing.jl")    # Tests for solution pretty printing
 include("test_robustness.jl")  # Line-search, bracketing-convergence, default_tol fixes
-include("test_fval_inputs.jl") # Pre-evaluated endpoints, BracketedSolution, NoTolerance
+include("test_fval_inputs.jl") # Pre-evaluated endpoints, TwoPointSolution, NoTolerance

--- a/test/test_fval_inputs.jl
+++ b/test/test_fval_inputs.jl
@@ -1,5 +1,5 @@
 # Tests for pre-evaluated endpoint residuals (`find_zero(f, M, x0, x1, y0, y1, ...)`),
-# the `BracketedSolution` solution type, the `NoTolerance` criterion, and the
+# the `TwoPointSolution` solution type, the `NoTolerance` criterion, and the
 # `maxiters <= 0` endpoint behavior of the two-point methods.
 
 const TWO_POINT_METHODS =
@@ -71,47 +71,90 @@ end
     end
 end
 
-@testset "BracketedSolution final state" begin
+@testset "TwoPointSolution final state" begin
     for FT in (Float32, Float64)
         f(x) = x^2 - FT(4)
         x0, x1 = FT(0), FT(3)
 
         for M in BRACKETING_METHODS
-            sol = find_zero(f, M, x0, x1, f(x0), f(x1), BracketedSolution())
-            @test sol isa RootSolvers.BracketedSolutionResults
+            sol = find_zero(f, M, x0, x1, f(x0), f(x1), TwoPointSolution())
+            @test sol isa RootSolvers.TwoPointSolutionResults
             @test isbits(sol)
             @test sol.converged === true
-            # The final points must still bracket the root, contain it, and carry
-            # consistent residuals.
+            # The final points must still bracket the root and contain it.
             @test sol.y0 * sol.y1 <= 0
             @test min(sol.x0, sol.x1) <= sol.root <= max(sol.x0, sol.x1)
-            @test sol.y0 === f(sol.x0)
-            @test sol.y1 === f(sol.x1)
             @test sol.err === f(sol.root)
+            # Residual consistency: bisection and Brent report the residuals as
+            # evaluated, but regula falsi's Illinois stagnation fix may have halved
+            # a retained endpoint's residual (sign and significand preserved, only
+            # the exponent reduced), so assert the invariant that survives damping.
+            for (xi, yi) in ((sol.x0, sol.y0), (sol.x1, sol.y1))
+                if M <: RegulaFalsiMethod
+                    @test significand(yi) === significand(f(xi))
+                    @test abs(yi) <= abs(f(xi))
+                else
+                    @test yi === f(xi)
+                end
+            end
 
             # No sign change: inputs are returned unchanged with converged = false.
-            sol_ns = find_zero(f, M, FT(3), FT(5), f(FT(3)), f(FT(5)), BracketedSolution())
+            sol_ns = find_zero(f, M, FT(3), FT(5), f(FT(3)), f(FT(5)), TwoPointSolution())
             @test sol_ns.converged === false
             @test (sol_ns.x0, sol_ns.x1) === (FT(3), FT(5))
             @test sol_ns.root === FT(3) # smaller-residual endpoint
         end
 
+        # Regula falsi with Illinois damping actually engaged: a strongly convex
+        # residual stagnates one-sided, so the retained endpoint's reported
+        # residual is a halved f value, not f itself.
+        f_convex(x) = x^10 - FT(1)
+        sol_ill = find_zero(
+            f_convex, RegulaFalsiMethod, FT(0), FT(1.3),
+            f_convex(FT(0)), f_convex(FT(1.3)),
+            TwoPointSolution(), NoTolerance(), 8,
+        )
+        @test sol_ill.y0 * sol_ill.y1 <= 0
+        @test min(sol_ill.x0, sol_ill.x1) <=
+              sol_ill.root <=
+              max(sol_ill.x0, sol_ill.x1)
+        damped =
+            (sol_ill.y0 !== f_convex(sol_ill.x0)) |
+            (sol_ill.y1 !== f_convex(sol_ill.x1))
+        @test damped # this case must exercise the Illinois fix
+        for (xi, yi) in ((sol_ill.x0, sol_ill.y0), (sol_ill.x1, sol_ill.y1))
+            @test significand(yi) === significand(f_convex(xi))
+            @test abs(yi) <= abs(f_convex(xi))
+        end
+
         # Secant: the two points are the last iterates (no bracketing guarantee).
-        sol_sec = find_zero(f, SecantMethod, x0, x1, f(x0), f(x1), BracketedSolution())
+        sol_sec = find_zero(f, SecantMethod, x0, x1, f(x0), f(x1), TwoPointSolution())
         @test sol_sec.converged === true
         @test sol_sec.root === sol_sec.x1
 
-        # One-point methods do not carry a two-point state.
+        # One-point methods do not carry a two-point state: pairing them with
+        # TwoPointSolution throws.
         @test_throws ArgumentError find_zero(
-            f, NewtonsMethodAD{FT}(FT(1)), BracketedSolution(),
+            f, NewtonsMethodAD{FT}(FT(1)), TwoPointSolution(),
         )
+        @test_throws ArgumentError find_zero(
+            x -> (f(x), 2x), NewtonsMethod{FT}(FT(1)), TwoPointSolution(),
+        )
+        # The guard fails fast, at dispatch, before evaluating `f` at all (rather
+        # than running the full solve and throwing at result construction).
+        n_eval = Ref(0)
+        g(x) = (n_eval[] += 1; f(x))
+        @test_throws ArgumentError find_zero(
+            g, NewtonsMethodAD{FT}(FT(1)), TwoPointSolution(), NoTolerance(), 10,
+        )
+        @test n_eval[] == 0
     end
 
     # Pretty printing
     sol =
-        find_zero(x -> x^2 - 4, RegulaFalsiMethod, 0.0, 3.0, -4.0, 5.0, BracketedSolution())
+        find_zero(x -> x^2 - 4, RegulaFalsiMethod, 0.0, 3.0, -4.0, 5.0, TwoPointSolution())
     str = sprint(show, sol)
-    @test occursin("BracketedSolutionResults", str)
+    @test occursin("TwoPointSolutionResults", str)
     @test occursin("Final points", str)
 end
 
@@ -158,7 +201,7 @@ end
 
 @testset "Pre-evaluated endpoints do not allocate" begin
     f_alloc(x) = x^2 - 4.0
-    for M in TWO_POINT_METHODS, soltype in (CompactSolution(), BracketedSolution())
+    for M in TWO_POINT_METHODS, soltype in (CompactSolution(), TwoPointSolution())
         @test fval_alloc_measure(f_alloc, M, soltype) == 0
     end
 end

--- a/test/test_fval_inputs.jl
+++ b/test/test_fval_inputs.jl
@@ -1,0 +1,164 @@
+# Tests for pre-evaluated endpoint residuals (`find_zero(f, M, x0, x1, y0, y1, ...)`),
+# the `BracketedSolution` solution type, the `NoTolerance` criterion, and the
+# `maxiters <= 0` endpoint behavior of the two-point methods.
+
+const TWO_POINT_METHODS =
+    (SecantMethod, BisectionMethod, RegulaFalsiMethod, BrentsMethod)
+const BRACKETING_METHODS = (BisectionMethod, RegulaFalsiMethod, BrentsMethod)
+
+@testset "Pre-evaluated endpoint residuals" begin
+    for FT in (Float32, Float64)
+        f(x) = x^2 - FT(4)
+        x0, x1 = FT(0), FT(3)
+        y0, y1 = f(x0), f(x1)
+        for M in TWO_POINT_METHODS
+            for soltype in (CompactSolution(), VerboseSolution())
+                sol_std = find_zero(f, M, x0, x1, soltype)
+                sol_pre = find_zero(f, M, x0, x1, y0, y1, soltype)
+                # Identical trajectories: pre-evaluating endpoints must not change
+                # the returned root or convergence status.
+                @test sol_pre.root === sol_std.root
+                @test sol_pre.converged === sol_std.converged
+            end
+
+            # The pre-evaluated form must save exactly the two endpoint evaluations.
+            cnt_std = Ref(0)
+            g_std(x) = (cnt_std[] += 1; x^2 - FT(4))
+            find_zero(g_std, M, x0, x1)
+            cnt_pre = Ref(0)
+            g_pre(x) = (cnt_pre[] += 1; x^2 - FT(4))
+            find_zero(g_pre, M, x0, x1, y0, y1)
+            @test cnt_std[] == cnt_pre[] + 2
+        end
+
+        # Wrong pre-evaluated values are the caller's responsibility, but non-finite
+        # ones must fail gracefully rather than iterate on garbage.
+        for M in TWO_POINT_METHODS
+            sol = find_zero(f, M, x0, x1, FT(NaN), y1)
+            @test sol.converged === false
+        end
+    end
+end
+
+@testset "NoTolerance runs exactly maxiters iterations" begin
+    for FT in (Float32, Float64)
+        x0, x1 = FT(0), FT(3)
+        for M in TWO_POINT_METHODS
+            maxiters = 7
+            cnt = Ref(0)
+            g(x) = (cnt[] += 1; x^2 - FT(4))
+            sol = find_zero(
+                g, M, x0, x1, g(x0), g(x1),
+                CompactSolution(), NoTolerance(), maxiters,
+            )
+            cnt[] -= 2 # remove the two explicit endpoint evaluations above
+            # NoTolerance never signals convergence...
+            @test sol.converged === false
+            # ...and (except for Brent's independent exact-zero exit) the iteration
+            # count is exactly maxiters.
+            if M <: BrentsMethod
+                @test cnt[] <= maxiters
+            else
+                @test cnt[] == maxiters
+            end
+            # The root estimate should nevertheless be accurate after 7 iterations
+            # (bisection converges linearly: |error| <= (x1 - x0) / 2^maxiters).
+            atol =
+                M <: BisectionMethod ? (x1 - x0) / 2^maxiters :
+                (FT == Float64 ? FT(1e-3) : FT(1e-2))
+            @test abs(sol.root - 2) <= atol
+        end
+    end
+end
+
+@testset "BracketedSolution final state" begin
+    for FT in (Float32, Float64)
+        f(x) = x^2 - FT(4)
+        x0, x1 = FT(0), FT(3)
+
+        for M in BRACKETING_METHODS
+            sol = find_zero(f, M, x0, x1, f(x0), f(x1), BracketedSolution())
+            @test sol isa RootSolvers.BracketedSolutionResults
+            @test isbits(sol)
+            @test sol.converged === true
+            # The final points must still bracket the root, contain it, and carry
+            # consistent residuals.
+            @test sol.y0 * sol.y1 <= 0
+            @test min(sol.x0, sol.x1) <= sol.root <= max(sol.x0, sol.x1)
+            @test sol.y0 === f(sol.x0)
+            @test sol.y1 === f(sol.x1)
+            @test sol.err === f(sol.root)
+
+            # No sign change: inputs are returned unchanged with converged = false.
+            sol_ns = find_zero(f, M, FT(3), FT(5), f(FT(3)), f(FT(5)), BracketedSolution())
+            @test sol_ns.converged === false
+            @test (sol_ns.x0, sol_ns.x1) === (FT(3), FT(5))
+            @test sol_ns.root === FT(3) # smaller-residual endpoint
+        end
+
+        # Secant: the two points are the last iterates (no bracketing guarantee).
+        sol_sec = find_zero(f, SecantMethod, x0, x1, f(x0), f(x1), BracketedSolution())
+        @test sol_sec.converged === true
+        @test sol_sec.root === sol_sec.x1
+
+        # One-point methods do not carry a two-point state.
+        @test_throws ArgumentError find_zero(
+            f, NewtonsMethodAD{FT}(FT(1)), BracketedSolution(),
+        )
+    end
+
+    # Pretty printing
+    sol =
+        find_zero(x -> x^2 - 4, RegulaFalsiMethod, 0.0, 3.0, -4.0, 5.0, BracketedSolution())
+    str = sprint(show, sol)
+    @test occursin("BracketedSolutionResults", str)
+    @test occursin("Final points", str)
+end
+
+@testset "Two-point methods with maxiters <= 0" begin
+    for FT in (Float32, Float64)
+        f(x) = x^2 - FT(4)
+        for M in TWO_POINT_METHODS
+            # Previously an UndefVarError for the bracketing kernel; must return the
+            # smaller-residual endpoint with converged = false.
+            sol = find_zero(f, M, FT(0), FT(3), f(FT(0)), f(FT(3)),
+                CompactSolution(), NoTolerance(), 0)
+            @test sol.converged === false
+            @test isfinite(sol.root)
+            if M <: Union{BisectionMethod, RegulaFalsiMethod}
+                @test sol.root === FT(0) # |f(0)| = 4 < |f(3)| = 5
+            end
+        end
+    end
+end
+
+@testset "Pre-evaluated endpoints with dual numbers" begin
+    # Differentiating through the solver must work when positions and residuals are
+    # dual numbers supplied by the caller (as in solvers embedded in AD-transparent code).
+    for M in BRACKETING_METHODS
+        function h(θ)
+            g(x) = x^2 - θ^2
+            x0 = θ - 1
+            x1 = θ + 1
+            sol = find_zero(g, M, x0, x1, g(x0), g(x1))
+            return sol.root^2
+        end
+        θ = 3.0
+        deriv = ForwardDiff.derivative(h, θ)
+        @test abs(deriv - 2 * θ) <= 2 * default_tol(Float64).tol
+    end
+end
+
+# Function barrier with forced method-type specialization, mirroring the
+# `find_zero_wrapper` pattern used by the allocation tests in `runtests.jl`.
+function fval_alloc_measure(f::F, ::Type{M}, soltype::S) where {F, M, S}
+    find_zero(f, M, 0.0, 3.0, -4.0, 5.0, soltype, NoTolerance(), 10) # compile
+    return @allocated find_zero(f, M, 0.0, 3.0, -4.0, 5.0, soltype, NoTolerance(), 10)
+end
+
+@testset "Pre-evaluated endpoints do not allocate" begin
+    f_alloc(x) = x^2 - 4.0
+    for M in TWO_POINT_METHODS, soltype in (CompactSolution(), BracketedSolution())
+        @test fval_alloc_measure(f_alloc, M, soltype) == 0
+    end
+end


### PR DESCRIPTION

* Provides new option to provide initial function evaluations at bracketing points at input (to avoid redundant function evaluations when they are available)
* Provides a new option to explicitly fix the iteration count for bracketing methods (rather than through the tol=0 workaround)
* A few smaller robustness fixes
* Bumps minor release